### PR TITLE
Tests: properly remove written files

### DIFF
--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -33,7 +33,7 @@ def _file_existing(request, filename, fdarg, objarg=None):
         request.addfinalizer(finalizer)
         return fd
     elif request.param == 'obj':
-        obj = open(filename, objarg)
+        obj = open(filename, objarg, buffering=False)
         request.addfinalizer(obj.close)
         return obj
 
@@ -608,21 +608,19 @@ def test_closing_should_close_file():
     assert f.closed
 
 
-def test_file_attributes_should_save_to_disk():
-    with sf.SoundFile(filename_new, 'w', 44100, 2, format='WAV') as f:
+def test_file_attributes_should_save_to_disk(file_w):
+    with sf.SoundFile(file_w, 'w', 44100, 2, format='WAV') as f:
         f.title = 'testing'
     with sf.SoundFile(filename_new) as f:
         assert f.title == 'testing'
-    os.remove(filename_new)
 
 
-def test_non_file_attributes_should_not_save_to_disk():
-    with sf.SoundFile(filename_new, 'w', 44100, 2, format='WAV') as f:
+def test_non_file_attributes_should_not_save_to_disk(file_w):
+    with sf.SoundFile(file_w, 'w', 44100, 2, format='WAV') as f:
         f.foobar = 'testing'
     with sf.SoundFile(filename_new) as f:
         with pytest.raises(AttributeError):
             f.foobar
-    os.remove(filename_new)
 
 
 # -----------------------------------------------------------------------------
@@ -651,8 +649,8 @@ def test_read_raw_files_with_too_few_arguments_should_fail():
 # -----------------------------------------------------------------------------
 
 
-def test_write_non_seekable_file():
-    with sf.SoundFile(filename_new, 'w', 44100, 1, format='XI') as f:
+def test_write_non_seekable_file(file_w):
+    with sf.SoundFile(file_w, 'w', 44100, 1, format='XI') as f:
         assert not f.seekable()
         assert f.frames == 0
         f.write(data_mono)


### PR DESCRIPTION
`test_write_non_seekable_file()` was writing the file `delme.please` and not removing it after the test.

Instead of using the file name directly, I changed this to use the parametrized fixture `file_w` which automatically removes the temporary file after usage (and even after a failure).
I also used that in 2 other test cases.

Finally, I changed the options for opening a Python file object to `buffering=False`, otherwise some of our tests wouldn't succeed because the data is not written to disk even if the corresponding `SoundFile` object is closed during the test.