### PR TITLE
Allow pipe read/write

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -673,6 +673,13 @@ class SoundFile(object):
                     # truncate the file, because SFM_RDWR doesn't:
                     _os.close(_os.open(file, _os.O_WRONLY | _os.O_TRUNC))
             self._file = _snd.sf_open(file.encode(), mode_int, self._info)
+            if mode_int == _snd.SFM_WRITE:
+                # Due to a bug in libsndfile version <= 1.0.25, frames != 0
+                # when opening a named pipe in SFM_WRITE mode.
+                # See http://github.com/erikd/libsndfile/issues/77.
+                self._info.frames = 0
+                # This is not necessary for "normal" files (because
+                # frames == 0 in this case), but it doesn't hurt, either.
         elif isinstance(file, int):
             self._file = _snd.sf_open_fd(file, mode_int, self._info, closefd)
         elif all(hasattr(file, a) for a in ('seek', 'read', 'write', 'tell')):


### PR DESCRIPTION
libsndfile can read from/write to a named pipe. We disabled this feature in #60 because we don't pass the file name directly to libsndfile anymore.

To make this possible again, we could check if a given file name is actually a pipe with

```python
import stat
import os
if stat.S_ISFIFO(os.stat(filename).st_mode):
    # call sf_open()
else:
    # call open() and sf_open_virtual(), as before
```

We'll probably have to catch an `OSError` if the file doesn't exist.

To try this, you can create a named pipe for writing:

    mkfifo writepipe
    cat writepipe

... and then use it:

```python
f = sf.open('writepipe', 'w', 44100, 1, format='au')
f.seekable()  # returns False
f.write([0.0, 0.1, 0.2])
f.close()
```

... or a named pipe for reading:

    mkfifo readpipe
    cat myfile.au > readpipe

... and read from it:

```python
f = sf.open('readpipe')
f.seekable()  # again False
f.read(10)
f.close()
```

Someone [on StackOverflow](http://stackoverflow.com/a/8370644/500098) claimed that named pipes don't work with `sf_open()`, but I tried it and it seems to work.

When using file descriptors, all this already works.