### PR TITLE
Rename module to "soundfile"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ manager, for example ``sudo apt-get install libsndfile``.
 With CFFI, Numpy, and libsndfile installed, you can use `pip
 <http://pip.readthedocs.org/en/latest/installing.html>`__ to install
 `PySoundFile <https://pypi.python.org/pypi/PySoundFile/0.6.0>`__ with
-``pip install PySoundFile`` or ``pip install PySoundFile --user`` if you
+``pip install pysoundfile`` or ``pip install pysoundfile --user`` if you
 don't have administrator privileges. If you are running Windows you
 should download the Windows installers for PySoundFile instead (which
 also include libsndfile):

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@ PySoundFile
 
 `PySoundFile <https://github.com/bastibe/PySoundFile>`__ is an audio
 library based on libsndfile, CFFI and Numpy. Full documentation is
-available on `pysoundfile.readthedocs.org
-<http://pysoundfile.readthedocs.org/>`__.
+available on http://pysoundfile.readthedocs.org/.
 
 PySoundFile can read and write sound files. File reading/writing is
 supported through `libsndfile <http://www.mega-nerd.com/libsndfile/>`__,
@@ -59,7 +58,7 @@ manager, for example ``sudo apt-get install libsndfile``.
 With CFFI, Numpy, and libsndfile installed, you can use `pip
 <http://pip.readthedocs.org/en/latest/installing.html>`__ to install
 `PySoundFile <https://pypi.python.org/pypi/PySoundFile/0.6.0>`__ with
-``pip install pysoundfile`` or ``pip install pysoundfile --user`` if you
+``pip install PySoundFile`` or ``pip install PySoundFile --user`` if you
 don't have administrator privileges. If you are running Windows you
 should download the Windows installers for PySoundFile instead (which
 also include libsndfile):
@@ -82,7 +81,7 @@ into an ogg-vorbis file:
 
 .. code:: python
 
-    import pysoundfile as sf
+    import soundfile as sf
 
     data, samplerate = sf.read('existing_file.wav')
     sf.write(data, 'new_file.ogg', samplerate=samplerate)
@@ -97,7 +96,7 @@ file:
 .. code:: python
 
    import numpy as np
-   import pysoundfile as sf
+   import soundfile as sf
 
    rms = [np.sqrt(np.mean(block**2)) for block in
           sf.blocks('myfile.wav', blocksize=1024, overlap=512)]
@@ -115,7 +114,7 @@ close the file explicitly:
 
 .. code:: python
 
-   import pysoundfile as sf
+   import soundfile as sf
 
    with sf.SoundFile('myfile.wav', 'rw') as f:
        while f.tell() < len(f):
@@ -138,7 +137,7 @@ file:
 
 .. code:: python
 
-   import pysoundfile as sf
+   import soundfile as sf
 
    format = {'format':'RAW', 'subtype':'FLOAT', 'endian':'FILE'}
    data = sf.read('myfile.raw', dtype='float32', **format)
@@ -152,7 +151,7 @@ regular files:
 
 .. code:: python
 
-    import pysoundfile as sf
+    import soundfile as sf
     with open('filename.flac', 'rb') as f:
         data, samplerate = sf.read(f)
 
@@ -161,7 +160,7 @@ Here is an example using an HTTP request:
 .. code:: python
 
     from io import BytesIO
-    import pysoundfile as sf
+    import soundfile as sf
     import requests
 
     f = BytesIO()

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@
 API Documentation
 =================
 
-.. automodule:: pysoundfile
+.. automodule:: soundfile
    :members:
    :undoc-members:
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     author_email='basti@bastibe.de',
     url='https://github.com/bastibe/PySoundFile',
     keywords=['audio', 'libsndfile'],
-    py_modules=['pysoundfile'],
+    py_modules=['soundfile'],
     data_files=sndfile,
     license='BSD 3-Clause License',
     install_requires=['numpy',

--- a/soundfile.py
+++ b/soundfile.py
@@ -312,7 +312,7 @@ def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> data, samplerate = sf.read('stereo_file.wav')
     >>> data
     array([[ 0.71329652,  0.06294799],
@@ -368,7 +368,7 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
     Write 10 frames of random data to a file:
 
     >>> import numpy as np
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> sf.write(np.random.randn(10, 2), 'stereo_file.wav', 44100, 'PCM_24')
 
     """
@@ -429,7 +429,7 @@ def blocks(file, blocksize=None, overlap=0, frames=-1, start=0, stop=None,
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> for block in sf.blocks('stereo_file.wav', blocksize=1024):
     >>>     pass  # do something with 'block'
 
@@ -447,7 +447,7 @@ def available_formats():
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> sf.available_formats()
     {'FLAC': 'FLAC (FLAC Lossless Audio Codec)',
      'OGG': 'OGG (OGG Container format)',
@@ -473,7 +473,7 @@ def available_subtypes(format=None):
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> sf.available_subtypes('FLAC')
     {'PCM_24': 'Signed 24 bit PCM',
      'PCM_16': 'Signed 16 bit PCM',
@@ -491,7 +491,7 @@ def check_format(format, subtype=None, endian=None):
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> sf.check_format('WAV', 'PCM_24')
     True
     >>> sf.check_format('FLAC', 'VORBIS')
@@ -509,7 +509,7 @@ def default_subtype(format):
 
     Examples
     --------
-    >>> import pysoundfile as sf
+    >>> import soundfile as sf
     >>> sf.default_subtype('WAV')
     'PCM_16'
     >>> sf.default_subtype('MAT5')
@@ -601,7 +601,7 @@ class SoundFile(object):
 
         Examples
         --------
-        >>> from pysoundfile import SoundFile
+        >>> from soundfile import SoundFile
 
         Open an existing file for reading:
 
@@ -831,7 +831,7 @@ class SoundFile(object):
 
         Examples
         --------
-        >>> from pysoundfile import SoundFile, SEEK_END
+        >>> from soundfile import SoundFile, SEEK_END
         >>> myfile = SoundFile('stereo_file.wav')
 
         Seek to the beginning of the file:
@@ -886,7 +886,7 @@ class SoundFile(object):
 
         Examples
         --------
-        >>> from pysoundfile import SoundFile
+        >>> from soundfile import SoundFile
         >>> myfile = SoundFile('stereo_file.wav')
 
         Reading 3 frames from a stereo file:

--- a/tests/test_argspec.py
+++ b/tests/test_argspec.py
@@ -1,6 +1,6 @@
 """Make sure that arguments of open/read/write don't diverge."""
 
-import pysoundfile as sf
+import soundfile as sf
 from inspect import getargspec
 
 

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -1,4 +1,4 @@
-import pysoundfile as sf
+import soundfile as sf
 import numpy as np
 import os
 import io


### PR DESCRIPTION
I always found the module name `pysoundfile` a bit clumsy to type and to speak about.
Also, `import pysoundfile as sf` didn't feel right, because `sf` isn't really an abbreviation of `pysoundfile`, it should rather be `psf`, but that's not nice, either.

I couldn't come up with a better suggestion, until I thought about possible package names for Debian (see #100). I think `python-soundfile` and `python3-soundfile` would be reasonable names for packages.

Which led me to the question: Why don't we just call the module `soundfile`?

This would be simpler, nicer to type and read, and the abbreviation `sf` would suddenly make sense:

```Python
import soundfile as sf
```

Also, `soundfile.SoundFile` looks more consistent to me than `pysoundfile.SoundFile`.

The project name on Github (the "marketing" name) should still be "PySoundFile", but inside Python code, the "`py`" isn't really necessary.

Of course, the same change could/should be made to PySoundCard, then the canonical header for a Python script would become:

```Python
import soundfile as sf
import soundcard as sc
```

... and code would look something like this:

```Python
data, fs = sf.read("myfile.wav")
sc.default.samplerate = fs
sc.play(data)
```

I had a quick look at PyPI and in the web, and I didn't find any real conflicts.
I know, I could've come up with this idea before 0.6.0, where we changed a lot of the API, but sadly, I just didn't.

Any opinions?