### PR TITLE
Don't throw exception if closefd is given for non-fd

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -662,9 +662,6 @@ class SoundFile(object):
                     "Not allowed for existing files (except 'RAW'): "
                     "samplerate, channels, format, subtype, endian")
 
-        if not closefd and not isinstance(file, int):
-            raise ValueError("closefd=False only allowed for file descriptors")
-
         if isinstance(file, str):
             if _os.path.isfile(file):
                 if 'x' in modes:

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -356,9 +356,6 @@ def test_open_with_more_invalid_arguments():
     with pytest.raises(ValueError) as excinfo:
         sf.SoundFile(filename_new, 'w', 44100, 2, endian='BOTH', format='WAV')
     assert "Invalid endian-ness" in str(excinfo.value)
-    with pytest.raises(ValueError) as excinfo:
-        sf.SoundFile(filename_stereo, closefd=False)
-    assert "closefd=False" in str(excinfo.value)
 
 
 def test_open_r_and_rplus_with_too_many_arguments():


### PR DESCRIPTION
The documentation already mentions that closefd is only applicable if a
file descriptor is used.