### PR TITLE
SoundFile.__init__(): replace manual string manipulation with os.path.splitext

### DIFF
--- a/pysoundfile.py
+++ b/pysoundfile.py
@@ -641,7 +641,8 @@ class SoundFile(object):
         old_fmt = format
         self._name = file
         if format is None:
-            format = str(getattr(file, 'name', file)).rsplit('.', 1)[-1]
+            extension = _os.path.splitext(str(getattr(file, 'name', file)))[-1]
+            format = extension.lstrip('.')
             if format.upper() not in _formats and 'r' not in modes:
                 raise TypeError(
                     "No format specified and unable to get format from "

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -201,6 +201,13 @@ def test_write_function(file_w):
     assert np.all(data == data_mono)
 
 
+@pytest.mark.parametrize("filename", ["wav", ".wav", "wav.py"])
+def test_write_with_unknown_extension(filename):
+    with pytest.raises(TypeError) as excinfo:
+        sf.write([0.0], filename, 44100)
+    assert "file extension" in str(excinfo.value)
+
+
 def test_write_with_exclusive_creation():
     with pytest.raises(OSError) as excinfo:
         sf.write(data_mono, filename_mono, 44100)


### PR DESCRIPTION
Instead of

```Python
somestring.rsplit('.', 1)[-1]
```

we should use

```Python
os.path.splitext(somestring)[-1].lstrip('.')
```

This would correctly handle the currently failing cases where the filename is `"wav"` or `".wav"`.

We might want to add something like this to the unit tests:

```Python
for name_with_unknown_extension in "wav", ".wav", "wav.py":
    with pytest.raises(TypeError) as excinfo:
        sf.SoundFile(name_with_unknown_extension, 'w', 44100, 1)
    assert "file extension" in str(excinfo.value)
```