### PR TITLE
Also include win/* when creating sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
+graft win
 recursive-include doc *.py *.rst *.txt Makefile
 recursive-include tests *.py *.wav *.raw


### PR DESCRIPTION
I have noticed the following under windows 

 - `pip install pysoundfile` does not work because the dll files do not exist and `shutil.copy2` fails.
 - Cloning the repository from GitHub and doing `pip install -e .` *does work*, because this way, the dll files do exist.

This has to do with the `win/` directory not being included in `MANIFEST.in` and thusly not being included in the `tar.gz` file when you do `python setup.py sdist`.

This PR fixes that, making sure that the dll files are included in future PyPI releases of this package.