### PR TITLE
Do not collect dist files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=dist


### PR DESCRIPTION
pytest currently fails on my machine with

    (pysoundfile)[user@mac PySoundFile (master)]$ py.test
    ============================= test session starts ==============================
    platform darwin -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4
    collected 168 items / 2 errors 

    dist/PySoundFile-0.6.0/tests/test_argspec.py ....
    dist/PySoundFile-0.6.0/tests/test_pysoundfile.py ....................................................................................................................................................................

    ==================================== ERRORS ====================================
    ____________________ ERROR collecting tests/test_argspec.py ____________________
    import file mismatch:
    imported module 'test_argspec' has this __file__ attribute:
      /Users/user/Projekte/pysoundfile/PySoundFile/dist/PySoundFile-0.6.0/tests/test_argspec.py
    which is not the same as the test file we want to collect:
      /Users/user/Projekte/pysoundfile/PySoundFile/tests/test_argspec.py
    HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
    __________________ ERROR collecting tests/test_pysoundfile.py __________________
    import file mismatch:
    imported module 'test_pysoundfile' has this __file__ attribute:
      /Users/user/Projekte/pysoundfile/PySoundFile/dist/PySoundFile-0.6.0/tests/test_pysoundfile.py
    which is not the same as the test file we want to collect:
      /Users/user/Projekte/pysoundfile/PySoundFile/tests/test_pysoundfile.py
    HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
    ===================== 168 passed, 2 error in 0.42 seconds ======================

which seems to be caused by pytest trying to collect stuff in `dist/` (no idea why it's not ignored by default). This `setup.cfg` tells pytest to ignore that directory.