### PR TITLE
Use actual base class instead of super()

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -751,7 +751,7 @@ class SoundFile(object):
             err = _snd.sf_set_string(self._file, _str_types[name], data)
             self._handle_error_number(err)
         else:
-            super(SoundFile, self).__setattr__(name, value)
+            object.__setattr__(self, name, value)
 
     def __getattr__(self, name):
         """Read text meta-data in the sound file through properties."""


### PR DESCRIPTION
`super()` is super for complicated class hierarchies, but for such simple cases I think it's not necessary.

I think to a large extent this is a matter of taste, I prefer to use `super()` only if its really necessary and if it actually makes a difference.

When searching around on the net, I found that the Python community seems to be torn about that issue.
It is considered everything between "super" and "harmful" ...