### PR TITLE
Add SoundFile.truncate()

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1007,20 +1007,27 @@ class SoundFile(object):
                 frames += overlap
             yield block
 
-    def truncate(self, frames=0):
+    def truncate(self, frames=None):
         """Truncate the file to a given number of frames.
 
         After this command, the read/write position will be at the new
         end of the file.
 
+        Parameters
+        ----------
+        frames : int, optional
+            Only the data before `frames` is kept, the rest is deleted.
+            If not specified, the current read/write position is used.
+
         """
+        if frames is None:
+            frames = self.tell()
         frames_ptr = _ffi.new("sf_count_t*", frames)
         err = _snd.sf_command(self._file, _snd.SFC_FILE_TRUNCATE, frames_ptr,
                               _ffi.sizeof("sf_count_t"))
         if err:
             raise RuntimeError("Error truncating the file")
-        else:
-            self._info.frames = frames
+        self._info.frames = frames
 
     def flush(self):
         """Write unwritten data to the file system.

--- a/soundfile.py
+++ b/soundfile.py
@@ -1022,8 +1022,8 @@ class SoundFile(object):
         """
         if frames is None:
             frames = self.tell()
-        frames_ptr = _ffi.new("sf_count_t*", frames)
-        err = _snd.sf_command(self._file, _snd.SFC_FILE_TRUNCATE, frames_ptr,
+        err = _snd.sf_command(self._file, _snd.SFC_FILE_TRUNCATE,
+                              _ffi.new("sf_count_t*", frames),
                               _ffi.sizeof("sf_count_t"))
         if err:
             raise RuntimeError("Error truncating the file")

--- a/soundfile.py
+++ b/soundfile.py
@@ -32,6 +32,7 @@ enum
     SFC_GET_FORMAT_MAJOR            = 0x1031,
     SFC_GET_FORMAT_SUBTYPE_COUNT    = 0x1032,
     SFC_GET_FORMAT_SUBTYPE          = 0x1033,
+    SFC_FILE_TRUNCATE               = 0x1080,
     SFC_SET_CLIPPING                = 0x10C0,
 } ;
 
@@ -1005,6 +1006,21 @@ class SoundFile(object):
                 self.seek(-overlap, SEEK_CUR)
                 frames += overlap
             yield block
+
+    def truncate(self, frames=0):
+        """Truncate the file to a given number of frames.
+
+        After this command, the read/write position will be at the new
+        end of the file.
+
+        """
+        frames_ptr = _ffi.new("sf_count_t*", frames)
+        err = _snd.sf_command(self._file, _snd.SFC_FILE_TRUNCATE, frames_ptr,
+                              _ffi.sizeof("sf_count_t"))
+        if err:
+            raise RuntimeError("Error truncating the file")
+        else:
+            self._info.frames = frames
 
     def flush(self):
         """Write unwritten data to the file system.

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -547,6 +547,21 @@ def test_seek_in_rplus_mode(sf_stereo_rplus):
     assert sf_stereo_rplus.tell() == 2
 
 
+def test_truncate(file_stereo_rplus):
+    if not isinstance(file_stereo_rplus, (str, int)):
+        # file objects don't support truncate()
+        return
+    with sf.SoundFile(file_stereo_rplus, 'r+', closefd=False) as f:
+        f.truncate(2)
+        assert f.tell() == 2
+        assert len(f) == 2
+    if isinstance(file_stereo_rplus, int):
+        os.lseek(file_stereo_rplus, 0, os.SEEK_SET)
+    data, fs = sf.read(file_stereo_rplus)
+    assert np.all(data == data_stereo[:2])
+    assert fs == 44100
+
+
 # -----------------------------------------------------------------------------
 # Test read
 # -----------------------------------------------------------------------------

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -547,12 +547,17 @@ def test_seek_in_rplus_mode(sf_stereo_rplus):
     assert sf_stereo_rplus.tell() == 2
 
 
-def test_truncate(file_stereo_rplus):
+@pytest.mark.parametrize("use_default", [True, False])
+def test_truncate(file_stereo_rplus, use_default):
     if not isinstance(file_stereo_rplus, (str, int)):
         # file objects don't support truncate()
         return
     with sf.SoundFile(file_stereo_rplus, 'r+', closefd=False) as f:
-        f.truncate(2)
+        if use_default:
+            f.seek(2)
+            f.truncate()
+        else:
+            f.truncate(2)
         assert f.tell() == 2
         assert len(f) == 2
     if isinstance(file_stereo_rplus, int):


### PR DESCRIPTION
Python file objects also [have this](https://docs.python.org/3/library/io.html#io.IOBase.truncate).

It looks like this can be done with the libsndfile command [SFC_FILE_TRUNCATE](http://www.mega-nerd.com/libsndfile/command.html#SFC_FILE_TRUNCATE).

Once we have this, we should replace the use of `os.open(..., os.O_TRUNC)` in `SoundFile.__init__()`.