### PR TITLE
Remove exclusive_creation argument from write() function

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -331,8 +331,10 @@ def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,
 
 
 def write(data, file, samplerate, subtype=None, endian=None, format=None,
-          closefd=True, exclusive_creation=True):
+          closefd=True):
     """Write data to a sound file.
+
+    .. note:: If `file` exists, it will be truncated and overwritten!
 
     Parameters
     ----------
@@ -356,9 +358,6 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
 
     Other Parameters
     ----------------
-    exclusive_creation : bool
-        If ``True`` (the default), the file is opened with ``mode='x'``.
-        Otherwise, it is opened with ``mode='w'``.
     format, endian, closefd
         See :class:`SoundFile`.
 
@@ -377,8 +376,7 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
         channels = 1
     else:
         channels = data.shape[1]
-    mode = 'x' if exclusive_creation else 'w'
-    with SoundFile(file, mode, samplerate, channels,
+    with SoundFile(file, 'w', samplerate, channels,
                    subtype, endian, format, closefd) as f:
         f.write(data)
 

--- a/tests/test_argspec.py
+++ b/tests/test_argspec.py
@@ -44,7 +44,6 @@ def test_read_defaults():
 
 def test_write_defaults():
     write_defaults = defaults(write_function)
-    del write_defaults['exclusive_creation']
     init_defaults = defaults(init)
 
     # Same default values as SoundFile.__init__()

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -214,12 +214,6 @@ def test_write_with_unknown_extension(filename):
     assert "file extension" in str(excinfo.value)
 
 
-def test_write_with_exclusive_creation():
-    with pytest.raises(OSError) as excinfo:
-        sf.write(data_mono, filename_mono, 44100)
-    assert "File exists" in str(excinfo.value)
-
-
 # -----------------------------------------------------------------------------
 # Test blocks() function
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This will revert the changes from #77.
Raising an error by default is useful in some cases, but it can also be harmful in other cases.

As far as I know, in most APIs the "write" function overwrites by default.
Also, e.g., the Unix commands `cp` and `mv` by default overwrite their target.

I think it's reasonable to assume that users expect overwriting behavior, therefore we should give it to them.

Once the default is changed to overwriting behavior, the argument `exclusive_creation` isn't that relevant anymore and it should be removed.

If users want to make sure that a file is not overwritten, they'll either have to check the existence first (e.g. with [`os.path.exists()`](https://docs.python.org/3/library/os.path.html#os.path.exists)) or they can use `f = SoundFile(..., mode='x')`.