### PR TITLE
Allow unicode filenames in Python 2

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -12,6 +12,7 @@ __version__ = "0.6.0"
 
 import numpy as _np
 import os as _os
+import sys as _sys
 from cffi import FFI as _FFI
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -681,7 +682,7 @@ class SoundFile(object):
 
         self._name = file
         if isinstance(file, _unicode):
-            file = file.encode()
+            file = file.encode(_sys.getfilesystemencoding())
 
         if isinstance(file, bytes):
             if _os.path.isfile(file):

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -363,13 +363,13 @@ def test_open_with_more_invalid_arguments():
     assert "integer" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         sf.SoundFile(filename_new, 'w', 44100, 2, format='WAF')
-    assert "Invalid format string" in str(excinfo.value)
+    assert "Unknown format" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         sf.SoundFile(filename_new, 'w', 44100, 2, 'PCM16', format='WAV')
-    assert "Invalid subtype string" in str(excinfo.value)
+    assert "Unknown subtype" in str(excinfo.value)
     with pytest.raises(ValueError) as excinfo:
         sf.SoundFile(filename_new, 'w', 44100, 2, endian='BOTH', format='WAV')
-    assert "Invalid endian-ness" in str(excinfo.value)
+    assert "Unknown endian-ness" in str(excinfo.value)
 
 
 def test_open_r_and_rplus_with_too_many_arguments():


### PR DESCRIPTION
Currently we check with `isinstance(file, str)`, which doesn't allow the Python 2 `unicode` type.

We should probably allow both "raw bytes" and "unicode" in both Python 2 and 3.
We would have to call `encode()` only on the "unicode" strings.
Alternatively, we could disallow Python 3 `bytes` objects, but I think it's better to allow them, because they are allowed for standard Python file objects, too.

I'm not sure which encoding is used by default, but we should check if we should probably change to `sys.getfilesystemencoding()`.
This idea is stolen from https://github.com/vokimon/python-wavefile

It's kind of annoying to check for unicode vs bytes, but I guess this would work in 2.6, 2.7 and 3.3+:

```Python
if isinstance(file, type(u"")):
    # unicode
if isinstance(file, type(b"")):
    # bytes
```

We could also just check if it's any of the "string-like" types and then `try` if there is an `encode()` method:

```Python
if isinstance(file, (type(u""), type(b""))):
    try:
        file = file.encode()
    except AttributeError:
        pass
```

In the combined check we could also use `isinstance(file, (type(u""), bytes))`, but I don't think that's better.

If Python 3.0-3.2 compatibility is important (which I think isn't), we could, instead of `type(u"")`, use `from __future__ import unicode_literals` and check for `type("")`, but this would lead to problems in other parts of the code (e.g. mode strings) where `isinstance(..., str)` would have to be extended to accept unicode in Python 2 (which would make things more complicated than before).

As yet another alternative, we could `try` to `encode()` before the type check and then drop the check for `str` and only check for `bytes`:

```Python
try:
    file = file.encode()
except AttributeError:
    pass
if isinstance(file, bytes):
    ...
elif isinstance(file, int):
    ...
...
```

I think this doesn't restrict compatibility and even looks nicer than the other alternatives, so it is probably the way to go.

There should probably also be tests, but I don't know how the encoding stuff can be reasonably tested cross-platform with the least effort.