### PR TITLE
support unicode filenames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
     data_files=sndfile,
     license='BSD 3-Clause License',
     install_requires=['numpy',
-                      'cffi>=0.6'],
+                      'cffi>=0.6',
+                      'six'],
     platforms='any',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/soundfile.py
+++ b/soundfile.py
@@ -12,6 +12,7 @@ __version__ = "0.6.0"
 
 import numpy as _np
 import os as _os
+import six
 from cffi import FFI as _FFI
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
@@ -621,7 +622,7 @@ class SoundFile(object):
         """
         if mode is None:
             mode = getattr(file, 'mode', None)
-        if not isinstance(mode, str):
+        if not isinstance(mode, six.string_types):
             raise TypeError("Invalid mode: {0!r}".format(mode))
         modes = set(mode)
         if modes.difference('xrwb+') or len(mode) > len(modes):
@@ -663,7 +664,7 @@ class SoundFile(object):
                     "Not allowed for existing files (except 'RAW'): "
                     "samplerate, channels, format, subtype, endian")
 
-        if isinstance(file, str):
+        if isinstance(file, six.string_types):
             if _os.path.isfile(file):
                 if 'x' in modes:
                     raise OSError("File exists: {0!r}".format(file))


### PR DESCRIPTION
I ran into a problem when one of my filenames was `u'file.ogg'` rather than `'file.ogg'` (str).

This patch swaps out the string type-check for `six.string_types`.  (I also threw it on `mode` while we're at it.)

This does add a dependency on the `six` module, so I understand if you'd prefer to do it manually instead.

Probably, there are other places where the code can be patched up to work more smoothly with unicode and/or general py2/py3 compatibility.  I haven't done a thorough check though.