### PR TITLE
Wheels are now os-dependent but python-independent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,29 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+try:
+    from wheel.bdist_wheel import bdist_wheel
+
+    class _bdist_wheel(bdist_wheel):
+        def get_tag(self):
+            tag = bdist_wheel.get_tag(self)
+            pythons = 'py2.py3.cp26.cp27.cp32.cp33.cp34.cp35.pp27.pp32'
+            if platform == 'darwin':
+                oses = 'macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_5_x86_64'
+            elif platform == 'win32':
+                if architecture0 == '32bit':
+                    oses = 'win32'
+                else:
+                    oses = 'win_amd64'
+            else:
+                oses = 'any'
+            tag = (pythons, 'none', oses)
+            return tag
+
+    cmdclass = {'bdist_wheel': _bdist_wheel}
+except ImportError:
+    cmdclass = {}
+
 setup(
     name='PySoundFile',
     version='0.6.0',
@@ -74,5 +97,5 @@ setup(
     ],
     long_description=open('README.rst').read(),
     tests_require=['pytest'],
-    cmdclass={'test': PyTest},
+    cmdclass=dict(cmdclass, test=PyTest)
 )

--- a/setup.py
+++ b/setup.py
@@ -43,28 +43,30 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
+cmdclass = {'test': PyTest}
 try:
     from wheel.bdist_wheel import bdist_wheel
 
-    class _bdist_wheel(bdist_wheel):
+    # This will create OS-dependent, but Python-independent wheels
+    class bdist_wheel_half_pure(bdist_wheel):
         def get_tag(self):
-            tag = bdist_wheel.get_tag(self)
             pythons = 'py2.py3.cp26.cp27.cp32.cp33.cp34.cp35.pp27.pp32'
             if platform == 'darwin':
-                oses = 'macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_5_x86_64'
+                oses = 'macosx_10_6_intel.macosx_10_9_intel.' \
+                       'macosx_10_9_x86_64.macosx_10_5_x86_64'
             elif platform == 'win32':
                 if architecture0 == '32bit':
                     oses = 'win32'
                 else:
                     oses = 'win_amd64'
             else:
+                pythons = 'py2.py3'
                 oses = 'any'
-            tag = (pythons, 'none', oses)
-            return tag
+            return pythons, 'none', oses
 
-    cmdclass = {'bdist_wheel': _bdist_wheel}
+    cmdclass['bdist_wheel'] = bdist_wheel_half_pure
 except ImportError:
-    cmdclass = {}
+    pass
 
 setup(
     name='PySoundFile',
@@ -97,5 +99,5 @@ setup(
     ],
     long_description=open('README.rst').read(),
     tests_require=['pytest'],
-    cmdclass=dict(cmdclass, test=PyTest)
+    cmdclass=cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,9 @@ class PyTest(TestCommand):
 cmdclass = {'test': PyTest}
 try:
     from wheel.bdist_wheel import bdist_wheel
-
+except ImportError:
+    pass
+else:
     # This will create OS-dependent, but Python-independent wheels
     class bdist_wheel_half_pure(bdist_wheel):
         def get_tag(self):
@@ -65,8 +67,6 @@ try:
             return pythons, 'none', oses
 
     cmdclass['bdist_wheel'] = bdist_wheel_half_pure
-except ImportError:
-    pass
 
 setup(
     name='PySoundFile',


### PR DESCRIPTION
This builds OS-dependent but Python-independent wheels.

I tested this on OSX, Win32, and Win64 and the wheels work fine.

The main point is that this should also work for `python setup.py bdist_wheel upload`.