### PR TITLE
Installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ PySoundFile
 ===========
 
 `PySoundFile <https://github.com/bastibe/PySoundFile>`__ is an audio
-library based on libsndfile, CFFI and Numpy. Full documentation is
+library based on libsndfile, CFFI and NumPy. Full documentation is
 available on http://pysoundfile.readthedocs.org/.
 
 PySoundFile can read and write sound files. File reading/writing is
@@ -39,22 +39,22 @@ might be removed in the future.
 Installation
 ------------
 
-PySoundFile depends on the Python packages CFFI and Numpy, and the
+PySoundFile depends on the Python packages CFFI and NumPy, and the
 system library libsndfile.
 
 To install the Python dependencies, I recommend using the `Anaconda
-<http://continuum.io/downloads#34>`__ Distribution of Python. This
-will come with all dependencies pre-installed. To install them
+<http://continuum.io/downloads>`__ distribution of Python 3. This will
+come with all dependencies pre-installed. To install the dependencies
 manually, you can use the ``conda`` package manager, which will
 install all dependencies using ``conda install cffi numpy`` (conda is
 also available independently of Anaconda with ``pip install conda;
 conda init``).
 
-With CFFI and Numpy installed, you can use ``pip install pysoundfile``
-to download and install the latest version of PySoundFile. On Windows
+With CFFI and NumPy installed, you can use ``pip install pysoundfile``
+to download and install the latest release of PySoundFile. On Windows
 and OS X, this will also install the library libsndfile. On Linux, you
 need to install libsndfile using your distribution's package manager,
-for example ``sudo apt-get install libsndfile``.
+for example ``sudo apt-get install libsndfile1``.
 
 Read/Write Functions
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -43,30 +43,18 @@ PySoundFile depends on the Python packages CFFI and Numpy, and the
 system library libsndfile.
 
 To install the Python dependencies, I recommend using the `Anaconda
-<http://continuum.io/downloads#34>`__ Distribution of Python. Anaconda
-provides the ``conda`` package manager, which will install all
-dependencies using ``conda install cffi numpy`` (conda is also
-independently available on pip).
+<http://continuum.io/downloads#34>`__ Distribution of Python. This
+will come with all dependencies pre-installed. To install them
+manually, you can use the ``conda`` package manager, which will
+install all dependencies using ``conda install cffi numpy`` (conda is
+also available independently of Anaconda with ``pip install conda;
+conda init``).
 
-You will also need to install `libsndfile
-<http://www.mega-nerd.com/libsndfile/>`__. On Windows, libsndfile is
-included in the binary installers (see below). On OS X, `homebrew
-<http://www.mega-nerd.com/libsndfile/>`__ can install libsndfile using
-``brew install libsndfile``. On Linux, use your distribution's package
-manager, for example ``sudo apt-get install libsndfile``.
-
-With CFFI, Numpy, and libsndfile installed, you can use `pip
-<http://pip.readthedocs.org/en/latest/installing.html>`__ to install
-`PySoundFile <https://pypi.python.org/pypi/PySoundFile/0.6.0>`__ with
-``pip install pysoundfile`` or ``pip install pysoundfile --user`` if you
-don't have administrator privileges. If you are running Windows you
-should download the Windows installers for PySoundFile instead (which
-also include libsndfile):
-
-| `PySoundFile-0.6.0.win-amd64-py2.7 <https://github.com/bastibe/PySoundFile/releases/download/0.6.0/PySoundFile-0.6.0.win-amd64-py2.7.exe>`__
-| `PySoundFile-0.6.0.win-amd64-py3.4 <https://github.com/bastibe/PySoundFile/releases/download/0.6.0/PySoundFile-0.6.0.win-amd64-py3.4.exe>`__
-| `PySoundFile-0.6.0.win32-py2.7 <https://github.com/bastibe/PySoundFile/releases/download/0.6.0/PySoundFile-0.6.0.win32-py2.7.exe>`__
-| `PySoundFile-0.6.0.win32-py3.4 <https://github.com/bastibe/PySoundFile/releases/download/0.6.0/PySoundFile-0.6.0.win32-py3.4.exe>`__
+With CFFI and Numpy installed, you can use ``pip install pysoundfile``
+to download and install the latest version of PySoundFile. On Windows
+and OS X, this will also install the library libsndfile. On Linux, you
+need to install libsndfile using your distribution's package manager,
+for example ``sudo apt-get install libsndfile``.
 
 Read/Write Functions
 --------------------


### PR DESCRIPTION
I have been using Python(x,y) and WinPython distributions, and I haven't yet installed any new packages.  I was reading the installation instructions from PySoundFile, and I was confused on a few items.

The PySoundFile instructions say that you need the library libsndfile installed on your computer.  When using the Windows installers, isn't libsndfile included and its DLL put in the PySoundFile folder?

The PySoundFile instructions say that you also need CFFI.  Python(x,y), which is for Windows, already contains CFFI.  The Anaconda distribution contains CFFI for Linux and OSX.  The PySoundFile instructions suggest using WinPython, but wouldn't one of these other distributions be simpler since they already contain CFFI?

The Anaconda distribution now has installers for Python 2.7 and 3.4, with Python 3.3 available only as an add-on environment (with no OS integration).  I intend to move to Python 3.4.  I request that the next release of PySoundFile support Python 2.7, 3.3 and 3.4.