### PR TITLE
Support Unicode filenames in Windows with sf_wchar_open()

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -135,6 +135,11 @@ typedef struct SF_FORMAT_INFO
 } SF_FORMAT_INFO ;
 """)
 
+if _sys.platform == 'win32':
+    _ffi.cdef("""
+    SNDFILE* sf_wchar_open (LPCWSTR wpath, int mode, SF_INFO *sfinfo) ;
+    """)
+
 _str_types = {
     'title':       0x01,
     'copyright':   0x02,
@@ -642,8 +647,6 @@ class SoundFile(object):
 
         """
         self._name = file
-        if isinstance(file, _unicode):
-            file = file.encode(_sys.getfilesystemencoding())
         if mode is None:
             mode = getattr(file, 'mode', None)
         mode_int = _check_mode(mode)
@@ -975,15 +978,20 @@ class SoundFile(object):
 
     def _open(self, file, mode_int, closefd):
         """Call the appropriate sf_open*() function from libsndfile."""
-        assert not isinstance(file, _unicode)
-        if isinstance(file, bytes):
+        if isinstance(file, (_unicode, bytes)):
             if _os.path.isfile(file):
                 if 'x' in self.mode:
                     raise OSError("File exists: {0!r}".format(self.name))
                 elif set(self.mode).issuperset('w+'):
                     # truncate the file, because SFM_RDWR doesn't:
                     _os.close(_os.open(file, _os.O_WRONLY | _os.O_TRUNC))
-            file_ptr = _snd.sf_open(file, mode_int, self._info)
+            openfunction = _snd.sf_open
+            if isinstance(file, _unicode):
+                if _sys.platform == 'win32':
+                    openfunction = _snd.sf_wchar_open
+                else:
+                    file = file.encode(_sys.getfilesystemencoding())
+            file_ptr = openfunction(file, mode_int, self._info)
         elif isinstance(file, int):
             file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
         elif all(hasattr(file, a) for a in ('seek', 'read', 'write', 'tell')):


### PR DESCRIPTION
I think #119 didn't go far enough regarding Unicode support.

It seems to work on Windows only as long as the file name can be encoded with `'mbcs'` encoding.
This works for me with innocuous names like `"äöüß.wav"`, but it doesn't work for more exotic names like `"☃.wav"`.

In this PR I'm activating the Windows-only function `sf_wchar_open()` to deal with Unicode file names on Windows.

I still don't know how to test all this in a meaningful way (see #122).
I did some informal tests on Windows XP and I'm able to write files with "strange" names, but those strange letters show up as rectangles when viewed in Windows Explorer (which I think is the expected behavior in my case).

I think it would be best to find a Windows system with some Asian language settings (or at least a system that can display the Unicode snowman in file names) to properly test this.