### PR TITLE
Don't require `'write'` attr for virtual file in read mode.

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -976,6 +976,9 @@ class SoundFile(object):
     def _open(self, file, mode_int, closefd):
         """Call the appropriate sf_open*() function from libsndfile."""
         assert not isinstance(file, _unicode)
+        readable = hasattr(file, 'read') or hasattr(file, 'readinto')
+        writeable = hasattr(file, 'write')
+        seekable = hasattr(file, 'seek') and hasattr(file, 'tell')
         if isinstance(file, bytes):
             if _os.path.isfile(file):
                 if 'x' in self.mode:
@@ -986,11 +989,11 @@ class SoundFile(object):
             file_ptr = _snd.sf_open(file, mode_int, self._info)
         elif isinstance(file, int):
             file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
-        elif ( hasattr(file, 'seek') and hasattr(file, 'tell') and
-               (hasattr(file, 'read') or mode_int == _snd.SFM_WRITE) and
-               (hasattr(file, 'write') or mode_int == _snd.SFM_READ) ):
-            file_ptr = _snd.sf_open_virtual(
-                self._init_virtual_io(file), mode_int, self._info, _ffi.NULL)
+        elif (seekable and
+              (readable or mode_int == _snd.SFM_WRITE) and
+              (writeable or mode_int == _snd.SFM_READ)):
+            file_ptr = _snd.sf_open_virtual(self._init_virtual_io(file),
+                                            mode_int, self._info, _ffi.NULL)
         else:
             raise TypeError("Invalid file: {0!r}".format(self.name))
         self._handle_error_number(_snd.sf_error(file_ptr),

--- a/soundfile.py
+++ b/soundfile.py
@@ -986,7 +986,9 @@ class SoundFile(object):
             file_ptr = _snd.sf_open(file, mode_int, self._info)
         elif isinstance(file, int):
             file_ptr = _snd.sf_open_fd(file, mode_int, self._info, closefd)
-        elif all(hasattr(file, a) for a in ('seek', 'read', 'write', 'tell')):
+        elif ( hasattr(file, 'seek') and hasattr(file, 'tell') and
+               (hasattr(file, 'read') or mode_int == _snd.SFM_WRITE) and
+               (hasattr(file, 'write') or mode_int == _snd.SFM_READ) ):
             file_ptr = _snd.sf_open_virtual(
                 self._init_virtual_io(file), mode_int, self._info, _ffi.NULL)
         else:


### PR DESCRIPTION
Also, don't require `'read'` attr for virtual file in write mode.

Because with that, I could `SoundFile(GridOut)`, where `GridOut` is a MongoDB database object. 