### PR TITLE
Pimp HTTP example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,17 +138,19 @@ Here is an example using an HTTP request:
 
 .. code:: python
 
-    from io import BytesIO
+    import io
     import soundfile as sf
-    import requests
+    from urllib.request import urlopen
+    
+    url = "http://tinyurl.com/shepard-risset"
+    data, samplerate = sf.read(io.BytesIO(urlopen(url).read()))
 
-    f = BytesIO()
-    response = requests.get('http://www.example.com/my.flac', stream=True)
-    for data in response.iter_content(4096):
-        if data:
-            f.write(data)
-    f.seek(0)
-    data, samplerate = sf.read(f)
+Note that the above example only works with Python 3.x.
+For Python 2.x support, replace the third line with:
+
+.. code:: python
+
+    from urllib2 import urlopen
 
 News
 ----


### PR DESCRIPTION
I wanted to load a sound file from an URL and had a look at the example in the README:

```Python
from io import BytesIO
import soundfile as sf
import requests

f = BytesIO()
response = requests.get('http://www.example.com/my.flac', stream=True)
for data in response.iter_content(4096):
    if data:
        f.write(data)
f.seek(0)
data, samplerate = sf.read(f)
```

I found out that this has a lot of shortcomings:

1. the URL doesn't exist
2. there is no meaningful exception message if the URL doesn't exist
3. it needs an external library (`requests`)
4. the for-loop looks very complicated for such a simple task
5. the if-clause within looks strange
6. the "stream" stuff gives false hope that PySoundFile might support streaming from file objects, which it doesn't

Point 1: I don't know a good example URL. The closest I could find are the WAV files here http://www.cs.bath.ac.uk/~rwd/cardattrit.html
Does anyone know a publicly available sound file with a nice URL?

Point 2 and 3 would be solved if we switch to the Python standard library.
The disadvantage would be that we have to take special care because the imports for Python 2 and 3 are different.
For me it would also be OK if we make the example Python-3-only.

Point 4, 5 and 6 can be avoided if we simply get the whole content (as bytes) from the HTTP library and shove it into a `BytesIO`.
Starting with CPython 3.5, there will be even one less copy because of an optimization in `BytesIO` (http://bugs.python.org/issue22003).

Here is my suggestion:

```Python
import io
import soundfile as sf
try:
    # Python 3.x
    from urllib.request import urlopen
except ImportError:
    # Python 2.x
    from urllib2 import urlopen

url = "http://www.cs.bath.ac.uk/~rwd/stereol.wav"
data, samplerate = sf.read(io.BytesIO(urlopen(url).read()))
```

I don't see a reason why we should need an external library for such a simple task, but just for completeness' sake, while still using `requests`, points 4, 5 and 6 could be avoided like this:

```Python
import requests
data, samplerate = sf.read(io.BytesIO(requests.get(url).content))
```