### PR TITLE
Don't use len() in the virtual IO setup

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1019,14 +1019,10 @@ class SoundFile(object):
         """Initialize callback functions for sf_open_virtual()."""
         @_ffi.callback("sf_vio_get_filelen")
         def vio_get_filelen(user_data):
-            # first try __len__(), if not available fall back to seek()/tell()
-            try:
-                size = len(file)
-            except TypeError:
-                curr = file.tell()
-                file.seek(0, SEEK_END)
-                size = file.tell()
-                file.seek(curr, SEEK_SET)
+            curr = file.tell()
+            file.seek(0, SEEK_END)
+            size = file.tell()
+            file.seek(curr, SEEK_SET)
             return size
 
         @_ffi.callback("sf_vio_seek")


### PR DESCRIPTION
Currently, we have this:

```Python
def vio_get_filelen(user_data):
    # first try __len__(), if not available fall back to seek()/tell()
    try:
        size = len(file)
    except TypeError:
        curr = file.tell()
        file.seek(0, SEEK_END)
        size = file.tell()
        file.seek(curr, SEEK_SET)
    return size
```

I suspect that the use of `len()` is a now obsolete artifact from the development in #1.
It was added there to seemingly support "streaming", but it turned out that this is not supported by the virtual IO call anyway.

Every supported file-like object *must have* the methods `seek()` and `tell()` anyway, so I think its superfluous to check with `len()` first.

Can we get rid of this remnant from the past?

I guess the cleaned-up version would look like this:

```Python
def vio_get_filelen(user_data):
    curr = file.tell()
    file.seek(0, SEEK_END)
    size = file.tell()
    file.seek(curr, SEEK_SET)
    return size
```

I'm wondering why `get_filelen` is even part of libsndfile's API, since it can be easily implemented with `seek` and `tell` ...?