### PR TITLE
Add documentation for potential contributors

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,73 @@
+Contributing
+------------
+
+If you find bugs, errors, omissions or other things that need improvement,
+please create an issue or a pull request at
+https://github.com/bastibe/PySoundFile/.
+Contributions are always welcome!
+
+Testing
+^^^^^^^
+
+If you fix a bug, you should add a test that exposes the bug (to avoid future
+regressions), if you add a feature, you should add tests for it as well.
+
+To run the tests, use::
+
+   python setup.py test
+
+This uses py.test_; if you haven't installed it already, it will be downloaded
+and installed for you.
+
+.. _py.test: http://pytest.org/
+
+.. note:: There is a `known problem`_ that prohibits the use of file
+   descriptors on Windows if the libsndfile DLL was compiled with a different
+   compiler than the Python interpreter.
+   Unfortunately, this is typically the case if the packaged DLLs are used.
+   To skip the tests which utilize file descriptors, use::
+
+      python setup.py test --pytest-args="-knot\ fd"
+
+   .. _known problem: http://www.mega-nerd.com/libsndfile/api.html#open_fd
+
+Coverage
+^^^^^^^^
+
+If you want to measure code coverage, you can use coverage.py_.
+Just install it with::
+
+   pip install coverage --user
+
+... and run it with::
+
+   coverage run --source soundfile.py -m py.test
+   coverage html
+
+The resulting HTML files will be written to the ``htmlcov/`` directory.
+
+You can even check `branch coverage`_::
+
+   coverage run --branch --source soundfile.py -m py.test
+   coverage html
+
+.. _coverage.py: http://nedbatchelder.com/code/coverage/
+.. _branch coverage: http://nedbatchelder.com/code/coverage/branch.html
+
+Documentation
+^^^^^^^^^^^^^
+
+If you make changes to the documentation, you can re-create the HTML pages
+on your local system using Sphinx_.
+
+.. _Sphinx: http://sphinx-doc.org/
+
+You can install it and a few other necessary packages with::
+
+   pip install -r doc/requirements.txt --user
+
+To create the HTML pages, use::
+
+   python setup.py build_sphinx
+
+The generated files will be available in the directory ``build/sphinx/html/``.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,7 @@
 .. include:: ../README.rst
 
+.. include:: ../CONTRIBUTING.rst
+
 API Documentation
 =================
 

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -75,6 +75,11 @@ def file_obj_stereo_rplus(request):
     return _file_copy(request, filename_stereo, os.O_RDWR, 'r+b')
 
 
+@pytest.fixture(params=['obj'])
+def file_obj_w(request):
+    return _file_new(request, os.O_CREAT | os.O_WRONLY, 'wb')
+
+
 @pytest.fixture(params=open_variants)
 def file_wplus(request):
     return _file_new(request, os.O_CREAT | os.O_RDWR, 'w+b')
@@ -484,8 +489,8 @@ def test_virtual_io_readonly(file_obj_stereo_rplus, readmethod):
     assert np.all(data == data_stereo)
 
 
-def test_virtual_io_writeonly(file_obj_stereo_rplus):
-    limitedfile = LimitedFile(file_obj_stereo_rplus, ['seek', 'tell', 'write'])
+def test_virtual_io_writeonly(file_obj_w):
+    limitedfile = LimitedFile(file_obj_w, ['seek', 'tell', 'write'])
     sf.write([0.5], limitedfile, 48000, format='WAV')
     data, fs = sf.read(filename_new)
     assert fs == 48000


### PR DESCRIPTION
As discussed in https://github.com/bastibe/PySoundFile/issues/29#issuecomment-49293101, we should document the tools we're using for the development of PySoundFile somewhere in the Sphinx documentation.

coverage:
https://github.com/bastibe/PySoundFile/issues/29#issuecomment-46548148
https://github.com/bastibe/PySoundFile/issues/29#issuecomment-49157194

py.test and file descriptors in Windows (see also #63):
https://github.com/bastibe/PySoundFile/pull/60#issuecomment-52160829