### PR TITLE
Rename pysoundfile_data -> _soundfile_data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "pysoundfile_data"]
-	path = pysoundfile_data
+[submodule "_soundfile_data"]
+	path = _soundfile_data
 	url = https://github.com/bastibe/libsndfile-binaries.git

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ else:
     libname = None
 
 if libname:
-    packages = ['pysoundfile_data']
-    package_data = {'pysoundfile_data': [libname, 'COPYING']}
+    packages = ['_soundfile_data']
+    package_data = {'_soundfile_data': [libname, 'COPYING']}
 else:
     packages = None
     package_data = None

--- a/soundfile.py
+++ b/soundfile.py
@@ -263,7 +263,7 @@ except OSError as err:
         raise
     _snd = _ffi.dlopen(_os.path.join(
         _os.path.dirname(_os.path.abspath(__file__)),
-        'pysoundfile_data', _libname))
+        '_soundfile_data', _libname))
 
 
 def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,


### PR DESCRIPTION
Prefixing this internal package name with an underscore should be less disruptive.