### PR TITLE
Change default value of always_2d to False

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -266,7 +266,7 @@ except OSError as err:
         '_soundfile_data', _libname))
 
 
-def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,
+def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=False,
          fill_value=None, out=None, samplerate=None, channels=None,
          format=None, subtype=None, endian=None, closefd=True):
     """Provide audio data from a sound file as NumPy array.
@@ -304,9 +304,9 @@ def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,
     audiodata : numpy.ndarray or type(out)
         A two-dimensional NumPy array is returned, where the channels
         are stored along the first dimension, i.e. as columns.
-        A two-dimensional array is returned even if the sound file has
-        only one channel. Use ``always_2d=False`` to return a
-        one-dimensional array in this case.
+        If the sound file has only one channel, a one-dimensional array
+        is returned.  Use ``always_2d=True`` to return a two-dimensional
+        array anyway.
 
         If `out` was specified, it is returned.  If `out` has more
         frames than available in the file (or if `frames` is smaller
@@ -319,10 +319,10 @@ def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=True,
     Other Parameters
     ----------------
     always_2d : bool, optional
-        By default, audio data is always returned as a two-dimensional
-        array, even if the audio file has only one channel.
-        With ``always_2d=False``, reading a mono sound file will return
-        a one-dimensional array.
+        By default, reading a mono sound file will return a
+        one-dimensional array.  With ``always_2d=True``, audio data is
+        always returned as a two-dimensional array, even if the audio
+        file has only one channel.
     fill_value : float, optional
         If more frames are requested than available in the file, the
         rest of the output is be filled with `fill_value`.  If
@@ -408,7 +408,7 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
 
 
 def blocks(file, blocksize=None, overlap=0, frames=-1, start=0, stop=None,
-           dtype='float64', always_2d=True, fill_value=None, out=None,
+           dtype='float64', always_2d=False, fill_value=None, out=None,
            samplerate=None, channels=None,
            format=None, subtype=None, endian=None, closefd=True):
     """Return a generator for block-wise reading.
@@ -784,7 +784,7 @@ class SoundFile(object):
         """Return the current read/write position."""
         return self.seek(0, SEEK_CUR)
 
-    def read(self, frames=-1, dtype='float64', always_2d=True,
+    def read(self, frames=-1, dtype='float64', always_2d=False,
              fill_value=None, out=None):
         """Read from the file and return data as NumPy array.
 
@@ -962,7 +962,7 @@ class SoundFile(object):
         self._update_len(written)
 
     def blocks(self, blocksize=None, overlap=0, frames=-1, dtype='float64',
-               always_2d=True, fill_value=None, out=None):
+               always_2d=False, fill_value=None, out=None):
         """Return a generator for block-wise reading.
 
         By default, the generator yields blocks of the given

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -9,7 +9,7 @@ data_stereo = np.array([[1.0,  -1.0],
                         [0.75, -0.75],
                         [0.5,  -0.5],
                         [0.25, -0.25]])
-data_mono = np.array([[0], [1], [2], [-2], [-1]], dtype='int16')
+data_mono = np.array([0, 1, 2, -2, -1], dtype='int16')
 
 filename_stereo = 'tests/stereo.wav'
 filename_mono = 'tests/mono.wav'
@@ -172,30 +172,30 @@ def test_if_read_into_zero_len_out_works(file_stereo_r):
     assert len(out) == 0
 
 
-def test_read_mono_without_always2d(file_mono_r):
-    data, fs = sf.read(file_mono_r, dtype='int16', always_2d=False)
-    assert data.ndim == 1
-    assert np.all(data == data_mono.squeeze())
-
-
-def test_if_read_mono_returns_2d_array(file_mono_r):
+def test_read_mono(file_mono_r):
     data, fs = sf.read(file_mono_r, dtype='int16')
-    assert data.ndim == 2
+    assert data.ndim == 1
     assert np.all(data == data_mono)
+
+
+def test_if_read_mono_with_always2d_returns_2d_array(file_mono_r):
+    data, fs = sf.read(file_mono_r, dtype='int16', always_2d=True)
+    assert data.ndim == 2
+    assert np.all(data == data_mono.reshape(-1, 1))
 
 
 def test_read_mono_into_1d_out(file_mono_r):
     out = np.empty(len(data_mono), dtype='int16')
     data, fs = sf.read(file_mono_r, out=out)
     assert data is out
-    assert np.all(data == data_mono.squeeze())
+    assert np.all(data == data_mono)
 
 
 def test_read_mono_into_2d_out(file_mono_r):
     out = np.empty((len(data_mono), 1), dtype='int16')
     data, fs = sf.read(file_mono_r, out=out)
     assert data is out
-    assert np.all(data == data_mono)
+    assert np.all(data == data_mono.reshape(-1, 1))
 
 
 def test_read_non_existing_file():
@@ -321,7 +321,7 @@ def test_blocks_with_out():
 
 def test_blocks_mono():
     blocks = list(sf.blocks(filename_mono, blocksize=3, dtype='int16',
-                            always_2d=False, fill_value=0))
+                            fill_value=0))
     assert_equal_list_of_arrays(blocks, [[0, 1, 2], [-2, -1, 0]])
 
 
@@ -460,7 +460,7 @@ def test_clipping_float_to_int(file_inmemory):
     written, expected = zip(*float_to_clipped_int16)
     sf.write(written, file_inmemory, 44100, format='WAV', subtype='PCM_16')
     file_inmemory.seek(0)
-    read, fs = sf.read(file_inmemory, always_2d=False, dtype='int16')
+    read, fs = sf.read(file_inmemory, dtype='int16')
     assert np.all(read == expected)
     assert fs == 44100
 
@@ -469,7 +469,7 @@ def test_non_clipping_float_to_float(file_inmemory):
     data = -2.0, -1.0, 0.0, 1.0, 2.0
     sf.write(data, file_inmemory, 44100, format='WAV', subtype='FLOAT')
     file_inmemory.seek(0)
-    read, fs = sf.read(file_inmemory, always_2d=False)
+    read, fs = sf.read(file_inmemory)
     assert np.all(read == data)
     assert fs == 44100
 


### PR DESCRIPTION
While I'm at suggesting breaking changes (see #132), I thought I might as well suggest another one ...

We discussed this already to quite some length in #16, but while I'm using it, I get the feeling that we may have chosen the wrong pill.

Arguments for `always_2d=True`:

* it's consistent in itself (everything is 2D, even mono signals)
* it's what you normally want in generic code (where you don't know if you get a mono or multi-channel file)

Arguments for `always_2d=False`:

* it's consistent with most of NumPy/SciPy (one-channel signals are 1D arrays)
* it's what you normally want in an interactive session (where you normally know if you are working on mono or multi-channel files)

I think we should simplify the interactive case, where being concise and the amount of typing matters most.
In the non-interactive case, it would even make the code more explicit and therefore easier to read, if people are forced to explicitly add `always_2d=True`.
This would be the equivalent to (but of course much simpler than) manually checking for the dimensions of an input array and reshaping it to the expected dimensionality, which is for sure done in many code bases.

There are several functions (like `matplotlib.pyplot.specgram()`) which only work on one-dimensional signals.
For those it would clearly be more practical to use `always_2d=False`.

There are other functions (like `numpy.fft.rfft()`) which work by default on `axis=-1`.
This works smoothly with `always_2d=False`, but it fails silently (just giving a completely wrong result) with `always_2d=True`.
For multi-channel files, people will have to explicitly use `axis=0` anyway, there is no way around this (and if they forget, they will get unexpected - a.k.a. wrong - results).

I would expect to be able to do the simple steps

1. load a mono file
1. compute its FFT

without having to specify some cryptic argument `always_2d=False`.

For people working mainly with mono signals (which is probably the majority of people working in audio and especially speech signal processing), it would be much more natural to have `always_2d=False` as default setting.

It would also make things simpler for people learning signal processing with NumPy/SciPy.
Here are 2 examples where I had to explicitly add `always_2d=False`:
http://nbviewer.jupyter.org/github/mgeier/jupyter-presentation/blob/master/jupyter-presentation.ipynb
http://nbviewer.jupyter.org/github/spatialaudio/communication-acoustics-exercises/blob/master/ir-solutions.ipynb

This makes the following steps much simpler and easier to understand, but of course the explicit argument `always_2d=False` confuses the hell out of students and colleagues.