### PR TITLE
Change order of arguments in soundfile.write()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ into an ogg-vorbis file:
     import soundfile as sf
 
     data, samplerate = sf.read('existing_file.wav')
-    sf.write(data, 'new_file.ogg', samplerate=samplerate)
+    sf.write('new_file.ogg', data, samplerate)
 
 Block Processing
 ----------------
@@ -120,7 +120,7 @@ file:
 
    format = {'format':'RAW', 'subtype':'FLOAT', 'endian':'FILE'}
    data = sf.read('myfile.raw', dtype='float32', **format)
-   sf.write(data, 'otherfile.raw', **format)
+   sf.write('otherfile.raw', data, **format)
 
 Virtual IO
 ----------

--- a/soundfile.py
+++ b/soundfile.py
@@ -355,7 +355,7 @@ def read(file, frames=-1, start=0, stop=None, dtype='float64', always_2d=False,
     return data, f.samplerate
 
 
-def write(data, file, samplerate, subtype=None, endian=None, format=None,
+def write(file, data, samplerate, subtype=None, endian=None, format=None,
           closefd=True):
     """Write data to a sound file.
 
@@ -363,6 +363,8 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
 
     Parameters
     ----------
+    file : str or int or file-like object
+        The file to write to.  See :class:`SoundFile` for details.
     data : array_like
         The data to write.  Usually two-dimensional (channels x frames),
         but one-dimensional `data` can be used for mono files.
@@ -373,8 +375,6 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
                   type of the written file.
                   Audio data will be converted to the given `subtype`.
 
-    file : str or int or file-like object
-        The file to write to.  See :class:`SoundFile` for details.
     samplerate : int
         The sample rate of the audio data.
     subtype : str, optional
@@ -393,7 +393,7 @@ def write(data, file, samplerate, subtype=None, endian=None, format=None,
 
     >>> import numpy as np
     >>> import soundfile as sf
-    >>> sf.write(np.random.randn(10, 2), 'stereo_file.wav', 44100, 'PCM_24')
+    >>> sf.write('stereo_file.wav', np.random.randn(10, 2), 44100, 'PCM_24')
 
     """
     import numpy as np

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -216,7 +216,7 @@ def test_read_non_existing_file():
 # The read() function is tested above, we assume here that it is working.
 
 def test_write_function(file_w):
-    sf.write(data_mono, file_w, 44100, format='WAV')
+    sf.write(file_w, data_mono, 44100, format='WAV')
     data, fs = sf.read(filename_new, dtype='int16')
     assert fs == 44100
     assert np.all(data == data_mono)
@@ -225,7 +225,7 @@ def test_write_function(file_w):
 @pytest.mark.parametrize("filename", ["wav", ".wav", "wav.py"])
 def test_write_with_unknown_extension(filename):
     with pytest.raises(TypeError) as excinfo:
-        sf.write([0.0], filename, 44100)
+        sf.write(filename, [0.0], 44100)
     assert "file extension" in str(excinfo.value)
 
 
@@ -463,7 +463,7 @@ def test_clipping_float_to_int(file_inmemory):
         ( 1.0         ,  2**15 - 1),
     ]
     written, expected = zip(*float_to_clipped_int16)
-    sf.write(written, file_inmemory, 44100, format='WAV', subtype='PCM_16')
+    sf.write(file_inmemory, written, 44100, format='WAV', subtype='PCM_16')
     file_inmemory.seek(0)
     read, fs = sf.read(file_inmemory, dtype='int16')
     assert np.all(read == expected)
@@ -472,7 +472,7 @@ def test_clipping_float_to_int(file_inmemory):
 
 def test_non_clipping_float_to_float(file_inmemory):
     data = -2.0, -1.0, 0.0, 1.0, 2.0
-    sf.write(data, file_inmemory, 44100, format='WAV', subtype='FLOAT')
+    sf.write(file_inmemory, data, 44100, format='WAV', subtype='FLOAT')
     file_inmemory.seek(0)
     read, fs = sf.read(file_inmemory)
     assert np.all(read == data)
@@ -496,7 +496,7 @@ def test_virtual_io_readonly(file_obj_stereo_rplus, readmethod):
 
 def test_virtual_io_writeonly(file_obj_w):
     limitedfile = LimitedFile(file_obj_w, ['seek', 'tell', 'write'])
-    sf.write([0.5], limitedfile, 48000, format='WAV')
+    sf.write(limitedfile, [0.5], 48000, format='WAV')
     data, fs = sf.read(filename_new)
     assert fs == 48000
     assert data == [0.5]


### PR DESCRIPTION
We had some discussions in the past about argument ordering (#54, #78), but I don't think we really talked about the order of the filename and the array argument in `soundfile.write()`.

I always thought it would make sense to write the array first and the filename later.
I would ask "What?" first, before I want to know "Where?".
It also makes some kind of sense if you think about the array as an "input" argument and the filename as an "output" argument. I'd normally mention the input arguments before the output arguments.

However, while I'm using the function, I come to think more and more that the order actually seems strange.
What bugged me in the beginning, is that the array and its sample rate (which belong together), are actually separated in the call (and the sample rate is obligatory!):

```Python
sf.write(data, 'my_audio_file.wav', fs)
```

Then I looked around and found that it's actually quite common to mention the file name first, e.g.:
http://docs.scipy.org/doc/numpy/reference/generated/numpy.savetxt.html
http://docs.scipy.org/doc/numpy/reference/generated/numpy.save.html
http://docs.scipy.org/doc/scipy/reference/generated/scipy.io.wavfile.write.html#scipy.io.wavfile.write
http://docs.scipy.org/doc/scipy/reference/generated/scipy.io.savemat.html
http://docs.scipy.org/doc/scipy/reference/generated/scipy.io.mmwrite.html#scipy.io.mmwrite

I hereby suggest that we change the order to:

```Python
sf.write('my_audio_file.wav', data, fs)
```

Apart from it being the way NumPy and SciPy do it, it would also be more consistent to (and compatible to) `soundfile.read()`, where the array and the sample rate are returned right next to each other.

Are there any counter-examples that mention the data to be saved before the file name?
Are there any other arguments?