### PR TITLE
Improve coverage

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -540,11 +540,8 @@ def default_subtype(format):
     'DOUBLE'
 
     """
-    try:
-        format = format.upper()
-    except AttributeError:
-        pass
-    return _default_subtypes.get(format)
+    _check_format(format)
+    return _default_subtypes.get(format.upper())
 
 
 class SoundFile(object):
@@ -1269,12 +1266,7 @@ def _error_check(err, prefix=""):
 
 def _format_int(format, subtype, endian):
     """Return numeric ID for given format|subtype|endian combo."""
-    if not isinstance(format, (_unicode, str)):
-        raise TypeError("Invalid format: {0!r}".format(format))
-    try:
-        result = _formats[format.upper()]
-    except KeyError:
-        raise ValueError("Unknown format: {0!r}".format(format))
+    result = _check_format(format)
     if subtype is None:
         subtype = default_subtype(format)
         if subtype is None:
@@ -1331,8 +1323,7 @@ def _create_info_struct(file, mode, samplerate, channels,
         format = _get_format_from_filename(file, mode)
         assert isinstance(format, (_unicode, str))
     else:
-        if not isinstance(format, (_unicode, str)):
-            raise TypeError("Invalid format: {0!r}".format(format))
+        _check_format(format)
 
     info = _ffi.new("SF_INFO*")
     if 'r' not in mode or format.upper() == 'RAW':
@@ -1401,3 +1392,14 @@ def _available_formats_helper(count_flag, format_flag):
     _snd.sf_command(_ffi.NULL, count_flag, count, _ffi.sizeof("int"))
     for format_int in range(count[0]):
         yield _format_info(format_int, format_flag)
+
+
+def _check_format(format_str):
+    """Check if `format_str` is valid and return format ID."""
+    if not isinstance(format_str, (_unicode, str)):
+        raise TypeError("Invalid format: {0!r}".format(format_str))
+    try:
+        format_int = _formats[format_str.upper()]
+    except KeyError:
+        raise ValueError("Unknown format: {0!r}".format(format_str))
+    return format_int

--- a/soundfile.py
+++ b/soundfile.py
@@ -1168,7 +1168,7 @@ class SoundFile(object):
 
         """
         if self.closed:
-            raise ValueError("I/O operation on closed file")
+            raise RuntimeError("I/O operation on closed file")
 
     def _check_frames(self, frames, fill_value):
         """Reduce frames to no more than are available in the file."""
@@ -1211,7 +1211,7 @@ class SoundFile(object):
         try:
             ctype = _ffi_types[array.dtype.name]
         except KeyError:
-            raise ValueError("dtype must be one of {0!r}".format(
+            raise TypeError("dtype must be one of {0!r}".format(
                 sorted(_ffi_types.keys())))
         assert array.dtype.itemsize == _ffi.sizeof(ctype)
         cdata = _ffi.cast(ctype + '*', array.__array_interface__['data'][0])

--- a/soundfile.py
+++ b/soundfile.py
@@ -1372,7 +1372,6 @@ def _format_str(format_int):
         for k, v in dictionary.items():
             if v == format_int:
                 return k
-    return hex(format_int)
 
 
 def _format_info(format_int, format_flag=_snd.SFC_GET_FORMAT_INFO):


### PR DESCRIPTION
I had to skip one test case for PyPy, because there seems to be a bug in PyPy 2.5, which says that an array is C-contiguous even if it isn't.
In PyPy 2.6.0 this seems to be fixed.

I couldn't find a way to get the PyPy version, so I just disabled it for all of PyPy.

Any idea how to get the PyPy version?

I changed a few exception types, but I'm not sure if those are correct.
I guess to some extent this is a matter of taste ...