### PR TITLE
RAW example in README is severely broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,8 @@ file:
 
    import soundfile as sf
 
-   format = {'format':'RAW', 'subtype':'FLOAT', 'endian':'FILE'}
-   data = sf.read('myfile.raw', dtype='float32', **format)
+   format = dict(format='RAW', subtype='FLOAT', endian='FILE', samplerate=44100)
+   data, samplerate = sf.read('myfile.raw', channels=1, dtype='float32', **format)
    sf.write('otherfile.raw', data, **format)
 
 Virtual IO
@@ -144,7 +144,7 @@ Here is an example using an HTTP request:
     import io
     import soundfile as sf
     from urllib.request import urlopen
-    
+
     url = "http://tinyurl.com/shepard-risset"
     data, samplerate = sf.read(io.BytesIO(urlopen(url).read()))
 

--- a/README.rst
+++ b/README.rst
@@ -113,17 +113,21 @@ RAW Files
 ---------
 
 Pysoundfile can usually auto-detect the file type of sound files. This
-is not possible for RAW files, though. This is a useful idiom for
-opening RAW files without having to provide all the format for every
-file:
+is not possible for RAW files, though:
 
 .. code:: python
 
    import soundfile as sf
 
-   format = dict(format='RAW', subtype='FLOAT', endian='FILE', samplerate=44100)
-   data, samplerate = sf.read('myfile.raw', channels=1, dtype='float32', **format)
-   sf.write('otherfile.raw', data, **format)
+   data, samplerate = sf.read('myfile.raw', channels=1, samplerate=44100,
+                              subtype='FLOAT')
+
+Note that on x86, this defaults to ``endian='LITTLE'``. If you are
+reading big endian data (mostly old PowerPC/6800-based files), you
+have to set ``endian`` accordingly.
+
+You can write RAW files in a similar way, but be advised that in most
+cases, a more expressive format is better and should be used instead.
 
 Virtual IO
 ----------

--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ is not possible for RAW files, though:
 
 Note that on x86, this defaults to ``endian='LITTLE'``. If you are
 reading big endian data (mostly old PowerPC/6800-based files), you
-have to set ``endian`` accordingly.
+have to set ``endian='BIG'`` accordingly.
 
 You can write RAW files in a similar way, but be advised that in most
 cases, a more expressive format is better and should be used instead.


### PR DESCRIPTION
There are surprisingly many bugs (even when not counting PEP-8 violations) in this (this is before #132):

```python
import soundfile as sf

format = {'format':'RAW', 'subtype':'FLOAT', 'endian':'FILE'}
data = sf.read('myfile.raw', dtype='float32', **format)
sf.write(data, 'otherfile.raw', **format)
```

This would be a variation that actually works (after merging #132):

```python
import soundfile as sf

format = dict(format='RAW', subtype='FLOAT', endian='FILE', samplerate=44100)
data, samplerate = sf.read('myfile.raw', channels=1, dtype='float32', **format)
assert samplerate == format['samplerate']
sf.write('otherfile.raw', data, **format)
```

Given this complexity, this is probably not such a "useful idiom" after all?

I hereby suggest to remove this example and replace it with an example for just reading a RAW file, which will show that all those arguments have to be given even for reading.

Reading RAW files is much more important than writing them, anyway.