### PR TITLE
Handle unsupported subtypes, add ALAC constants

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1521,6 +1521,8 @@ def _format_str(format_int):
         for k, v in dictionary.items():
             if v == format_int:
                 return k
+    else:
+        return 'n/a'
 
 
 def _format_info(format_int, format_flag=_snd.SFC_GET_FORMAT_INFO):

--- a/soundfile.py
+++ b/soundfile.py
@@ -210,6 +210,10 @@ _subtypes = {
     'DPCM_8':    0x0050,  # 8 bit differential PCM (XI only)
     'DPCM_16':   0x0051,  # 16 bit differential PCM (XI only)
     'VORBIS':    0x0060,  # Xiph Vorbis encoding.
+    'ALAC_16':   0x0070,  # Apple Lossless Audio Codec (16 bit).
+    'ALAC_20':   0x0071,  # Apple Lossless Audio Codec (20 bit).
+    'ALAC_24':   0x0072,  # Apple Lossless Audio Codec (24 bit).
+    'ALAC_32':   0x0073,  # Apple Lossless Audio Codec (32 bit).
 }
 
 _endians = {


### PR DESCRIPTION
I happended to use PySoundFile with a development version of libsndfile and found that `available_subtypes()` lists the new ALAC subtype, but since there is no string for it, it just prints `None`.
This in turn leads to unknown subtypes being listed in `available_subtypes('WAV')`, because `subtype=None` passes the check for a valid format/subtype combo.

This PR replaces this with `'n/a'` and then adds another commit with the new subtype codes for ALAC.