### PR TITLE
Remove empty line before class docstrings

### DIFF
--- a/doc/fake_cffi.py
+++ b/doc/fake_cffi.py
@@ -2,6 +2,7 @@
 
 
 class FFI(object):
+
     def cdef(self, _):
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ else:
 
 
 class PyTest(TestCommand):
+
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
     def initialize_options(self):
@@ -62,8 +63,10 @@ try:
 except ImportError:
     pass
 else:
+
     class bdist_wheel_half_pure(bdist_wheel):
         """Create OS-dependent, but Python-independent wheels."""
+
         def get_tag(self):
             pythons = 'py2.py3.' + PYTHON_INTERPRETERS
             if platform == 'darwin':

--- a/soundfile.py
+++ b/soundfile.py
@@ -485,6 +485,7 @@ def blocks(file, blocksize=None, overlap=0, frames=-1, start=0, stop=None,
 
 class _SoundFileInfo(object):
     """Information about a SoundFile"""
+
     def __init__(self, file, verbose):
         self.verbose = verbose
         with SoundFile(file) as f:
@@ -620,7 +621,6 @@ def default_subtype(format):
 
 
 class SoundFile(object):
-
     """A sound file.
 
     For more documentation see the __init__() docstring (which is also

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -522,6 +522,7 @@ def test_if_open_with_mode_w_truncates(file_stereo_rplus, mode):
 
 
 class LimitedFile(object):
+
     def __init__(self, file, attrs):
         for attr in attrs:
             setattr(self, attr, getattr(file, attr))


### PR DESCRIPTION
Some time ago, they changed this in PEP 257.