### PR TITLE
Replace <ORGANIZATION> placeholder in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ met:
     notice, this list of conditions and the following disclaimer in
     the documentation and/or other materials provided with the
     distribution.
-  * Neither the name of the <ORGANIZATION> nor the names
+  * Neither the name of PySoundFile nor the names
     of its contributors may be used to endorse or promote products
     derived from this software without specific prior written
     permission.


### PR DESCRIPTION
In other projects, I've also seen the project name in quotes, but I think it's more common without the quotes and to me it makes more sense.