### PR TITLE
Check for _soundfile_data directory in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ elif platform == 'win32':
 else:
     libname = None
 
-if libname:
+if libname and os.path.isdir('_soundfile_data'):
     packages = ['_soundfile_data']
     package_data = {'_soundfile_data': [libname, 'COPYING']}
 else:


### PR DESCRIPTION
Without this, a non-Linux build from the tarball will fail.

See https://github.com/spatialaudio/python-sounddevice/issues/16 for an example error message.