### PR TITLE
Allow (whole) floating-point values for samplerate

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1490,7 +1490,8 @@ def _create_info_struct(file, mode, samplerate, channels,
             raise TypeError("samplerate must be specified")
         info.samplerate = int(samplerate)
         if info.samplerate != samplerate:
-            raise ValueError("Invalid samplerate: {0!r}".format(samplerate))
+            raise ValueError(
+                "samplerate must be a whole number: {0!r}".format(samplerate))
         if channels is None:
             raise TypeError("channels must be specified")
         info.channels = channels

--- a/soundfile.py
+++ b/soundfile.py
@@ -1488,7 +1488,9 @@ def _create_info_struct(file, mode, samplerate, channels,
     if 'r' not in mode or format.upper() == 'RAW':
         if samplerate is None:
             raise TypeError("samplerate must be specified")
-        info.samplerate = samplerate
+        info.samplerate = int(samplerate)
+        if info.samplerate != samplerate:
+            raise ValueError("Invalid samplerate: {0!r}".format(samplerate))
         if channels is None:
             raise TypeError("channels must be specified")
         info.channels = channels

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -286,6 +286,19 @@ def test_write_with_unknown_extension(filename):
     assert "file extension" in str(excinfo.value)
 
 
+def test_write_with_float_samplerate(file_inmemory):
+    sf.write(file_inmemory, data_mono, 44100.0, format='WAV')
+    file_inmemory.seek(0)
+    read, fs = sf.read(file_inmemory, always_2d=False, dtype='int16')
+    assert np.all(read == data_mono)
+    assert fs == 44100
+    assert type(fs) == int
+
+    with pytest.raises(ValueError) as excinfo:
+        sf.write(file_inmemory, data_mono, 44099.9, format='WAV')
+    assert 'samplerate' in str(excinfo.value)
+
+
 # -----------------------------------------------------------------------------
 # Test blocks() function
 # -----------------------------------------------------------------------------
@@ -433,9 +446,9 @@ def test_open_with_invalid_mode():
 
 
 def test_open_with_more_invalid_arguments():
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         sf.SoundFile(filename_new, 'w', 3.1415, 2, format='WAV')
-    assert "integer" in str(excinfo.value)
+    assert "samplerate" in str(excinfo.value)
     with pytest.raises(TypeError) as excinfo:
         sf.SoundFile(filename_new, 'w', 44100, 3.1415, format='WAV')
     assert "integer" in str(excinfo.value)


### PR DESCRIPTION
E.g. PortAudio uses `float` values for the samplerate, this makes using them simple.

This avoids having to make the conversion manually, like e.g. [here](https://github.com/spatialaudio/python-sounddevice/blob/68a30f8da513ae15e517c5d27d4ae4755ca9f368/examples/rec_unlimited.py#L49).