### PR TITLE
DOC: Add missing member functions in fake CFFI class

### DIFF
--- a/doc/fake_cffi.py
+++ b/doc/fake_cffi.py
@@ -9,4 +9,10 @@ class FFI(object):
     def dlopen(self, _):
         return self
 
+    def string(self, _):
+        return b'not implemented'
+
+    def sf_version_string(self):
+        return NotImplemented
+
     SFC_GET_FORMAT_INFO = NotImplemented


### PR DESCRIPTION
PR #160 introduced those calls on module load, which broke the Sphinx autodoc generation.