### PR TITLE
Adds raw_read/raw_write to exposed API

### DIFF
--- a/soundfile.py
+++ b/soundfile.py
@@ -1041,10 +1041,6 @@ class SoundFile(object):
         
         assert read_bytes == nbytes
 
-        endswap = _snd.sf_command(self._file, _snd.SFC_RAW_DATA_NEEDS_ENDSWAP,
-                                  _ffi.NULL, 0)
-        assert not endswap
-
         return _ffi.buffer(cdata)
 
     def read_raw_into(self, buffer, dtype=None):
@@ -1108,7 +1104,6 @@ class SoundFile(object):
         if self.seekable():
             self.seek(curr + frames, SEEK_SET)  # Update read & write position
         
-        assert not self.endian_swapped
         return frames
 
     def buffer_read(self, frames=-1, ctype=None, dtype=None):

--- a/soundfile.py
+++ b/soundfile.py
@@ -1083,7 +1083,7 @@ class SoundFile(object):
 
         #_check_buffer
         if not isinstance(buffer, bytes):
-            buffer = _ffi.from_buffer(buffer)
+            cdata = _ffi.from_buffer(buffer)
         else:
             cdata = buffer
         frames, remainder = divmod(len(cdata),

--- a/soundfile.py
+++ b/soundfile.py
@@ -261,8 +261,6 @@ _ffi_types = {
     'float32': 'float',
     'int32': 'int',
     'int16': 'short',
-    'int8': 'char',
-    'uint8': 'unsigned char',
 }
 
 _samplesize = {


### PR DESCRIPTION
adds support for reading/writing files directly from byte buffers for additional 'dtype' formats:
- int24
- int8
- uint8
    
Notes:
+ raw_read/write only supports dtype argument since 'int24' has no native ctype
+ much of the functionality of _check_buffer/_cdata_io/_check_dtype has been rewritten into these functions specifically because the current functions aren't intended to handle int24 types
