### PR TITLE
Extend supported wheel versions with cp36 and pp33

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ import sys
 
 PYTHON_INTERPRETERS = '.'.join([
     'cp26', 'cp27',
-    'cp32', 'cp33', 'cp34', 'cp35',
+    'cp32', 'cp33', 'cp34', 'cp35', 'cp36',
     'pp27',
-    'pp32',
+    'pp32', 'pp33',
 ])
 MACOSX_VERSIONS = '.'.join([
     'macosx_10_5_x86_64',


### PR DESCRIPTION
I don't know if in the meantime there is a saner way to support basically all Python versions in a non-pure wheel ...