### PR TITLE
DOC: Change 'rw' to 'r+' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ context manager to close the file explicitly:
 
    import soundfile as sf
 
-   with sf.SoundFile('myfile.wav', 'rw') as f:
+   with sf.SoundFile('myfile.wav', 'r+') as f:
        while f.tell() < len(f):
            pos = f.tell()
            data = f.read(1024)


### PR DESCRIPTION
It's quite a long time ago, but we seem to have missed this in #26.
I guess the PR was created before #60 (where it was still accurate) but merged after it ...