### PR TITLE
Update SoundFile.blocks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 build/
 PySoundFile.egg-info/
 .eggs/
+*.egg-info/
+.cache/
+.vscode/

--- a/soundfile.py
+++ b/soundfile.py
@@ -1185,6 +1185,8 @@ class SoundFile(object):
         >>>         pass  # do something with 'block'
 
         """
+        import numpy as np
+
         if 'r' not in self.mode and '+' not in self.mode:
             raise RuntimeError("blocks() is not allowed in write-only mode")
 
@@ -1206,15 +1208,12 @@ class SoundFile(object):
         # Get the number of remaining frames
         frames = self._check_frames(frames, fill_value)
         while frames > 0:
-            n = min(blocksize - offset, frames)
-            self.read(n, dtype, always_2d, fill_value, out[offset:])
-            block = out[:min(blocksize, frames + overlap)] if fill_value is None else out
-            if copy_out:
-                import numpy as np
-                yield np.copy(block)
-            else:
-                yield block
-            frames -= n
+            toread = min(blocksize - offset, frames)
+            self.read(toread, dtype, always_2d, fill_value, out[offset:])
+            block = out[:frames + overlap] if blocksize > frames + overlap and fill_value is None \
+                else out
+            yield np.copy(block) if copy_out else block
+            frames -= toread
             # Copy the end of the block to the beginning of the next
             if overlap:
                 offset = overlap

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -382,6 +382,17 @@ def test_blocks_with_out(file_stereo_r):
         list(sf.blocks(filename_stereo, blocksize=3, out=out))
 
 
+def test_blocks_inplace_modification(file_stereo_r):
+    out = np.empty((3, 2))
+    blocks = []
+    for block in sf.blocks(file_stereo_r, out=out, overlap=1):
+        blocks.append(np.copy(block))
+        block *= 2
+
+    expected_blocks = [data_stereo[0:3], data_stereo[2:5]]
+    assert_equal_list_of_arrays(blocks, expected_blocks)
+
+
 def test_blocks_mono():
     blocks = list(sf.blocks(filename_mono, blocksize=3, dtype='int16',
                             fill_value=0))

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -371,7 +371,7 @@ def test_blocks_with_frames_and_fill_value(file_stereo_r):
 def test_blocks_with_out(file_stereo_r):
     out = np.empty((3, 2))
     blocks = list(sf.blocks(file_stereo_r, out=out))
-    assert blocks[0] is out
+    assert blocks[0].base is out
     # First frame was overwritten by second block:
     assert np.all(blocks[0] == data_stereo[[3, 1, 2]])
 
@@ -1006,10 +1006,6 @@ def test_write_non_seekable_file(file_w):
         with pytest.raises(ValueError) as excinfo:
             f.read()
         assert "frames" in str(excinfo.value)
-
-        with pytest.raises(ValueError) as excinfo:
-            list(f.blocks(blocksize=3, overlap=1))
-        assert "overlap" in str(excinfo.value)
 
     data, fs = sf.read(filename_new, dtype='int16')
     assert np.all(data == data_mono)

--- a/tests/test_pysoundfile.py
+++ b/tests/test_pysoundfile.py
@@ -371,7 +371,7 @@ def test_blocks_with_frames_and_fill_value(file_stereo_r):
 def test_blocks_with_out(file_stereo_r):
     out = np.empty((3, 2))
     blocks = list(sf.blocks(file_stereo_r, out=out))
-    assert blocks[0].base is out
+    assert blocks[0] is out
     # First frame was overwritten by second block:
     assert np.all(blocks[0] == data_stereo[[3, 1, 2]])
 


### PR DESCRIPTION
This PR removes the necessity to seek in the input file when generating blocks because seeking is relatively expensive. Here is a benchmark on an [ACDC snippet](https://en.wikipedia.org/wiki/File:ACDC_-_Back_In_Black-sample.ogg) (25 seconds) and a [metal podcast](http://archive.org/download/OpenMetalcastEpisode162InfinitePossibilities/open_metalcast_162.ogg) (32 mins, 15 seconds).

```python
# profile.py
import soundfile
import tqdm
import sys

with soundfile.SoundFile(sys.argv[1]) as sf:
    for _ in tqdm.tqdm(sf.blocks(6 * sf.samplerate, sf.samplerate)):
        pass
```

```
$ python profile.py ACDC_-_Back_In_Black-sample.ogg
5it [00:00, 20.51it/s]  # on master
$ python profile.py ACDC_-_Back_In_Black-sample.ogg
5it [00:00, 30.96it/s]  # with this patch
```

```
$ python profile.py open_metalcast_162.ogg
214it [05:03,  2.69s/it]  # on master (cancelled after five minutes)
$ python profile.py open_metalcast_162.ogg
5.379634857177734  # with this patch
```

One interesting observation: The code on `master` starts of a bit slower than the patched version on long files but becomes much slower as it processes more of the file. Maybe because the implementation seeks from the beginning of the file rather than doing a relative seek from the current position?