### PR TITLE
DOC: fix fake import for API docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -277,5 +277,5 @@ napoleon_include_special_with_doc = False
 # Fake imports to avoid actually loading NumPy and libsndfile
 import fake_numpy
 sys.modules['numpy'] = sys.modules['fake_numpy']
-import fake_cffi
-sys.modules['cffi'] = sys.modules['fake_cffi']
+import fake__soundfile
+sys.modules['_soundfile'] = sys.modules['fake__soundfile']

--- a/doc/fake__soundfile.py
+++ b/doc/fake__soundfile.py
@@ -1,10 +1,7 @@
 """Mock module for Sphinx autodoc."""
 
 
-class FFI(object):
-
-    def cdef(self, _):
-        pass
+class ffi(object):
 
     def dlopen(self, _):
         return self
@@ -16,3 +13,6 @@ class FFI(object):
         return NotImplemented
 
     SFC_GET_FORMAT_INFO = NotImplemented
+
+
+ffi = ffi()


### PR DESCRIPTION
Switching to out-of-line ABI mode (#211) broke this.
See also https://github.com/spatialaudio/python-sounddevice/pull/105.